### PR TITLE
Checklist sources

### DIFF
--- a/src/State.ts
+++ b/src/State.ts
@@ -1,4 +1,4 @@
-import checklistData from "./data/checklist.json";
+import { checklistData } from "~/composables/Checklist";
 import { version } from "../package.json";
 import { createGlobalState, useStorage } from "@vueuse/core";
 import { ref } from "vue";

--- a/src/composables/Cards.ts
+++ b/src/composables/Cards.ts
@@ -19,7 +19,7 @@ export type Card = {
   source?: string;
 };
 
-export const Cards: Card[] = [
+const BlunderHillCards: Card[] = [
   {
     id: "Green_Mushroom",
     category: CardCategory.BlunderHills,
@@ -132,6 +132,9 @@ export const Cards: Card[] = [
     base: 5,
     source: "Wood Mushroom (1/10,000)",
   },
+]
+
+const YumYumDesertCards: Card[] = [
   {
     id: "Sandy_Pot",
     category: CardCategory.YumYumDesert,
@@ -230,6 +233,9 @@ export const Cards: Card[] = [
     base: 1,
     source: "Survive Bandit Bob",
   },
+];
+
+const EasyResourcesCards: Card[] = [
   {
     id: "Copper_Ore",
     category: CardCategory.EasyResources,
@@ -321,6 +327,9 @@ export const Cards: Card[] = [
     base: 5,
     source: "Catching Butterflies",
   },
+];
+
+const MediumResourcesCards: Card[] = [
   {
     id: "Platinum_Ore",
     category: CardCategory.MediumResources,
@@ -426,6 +435,9 @@ export const Cards: Card[] = [
     base: 5,
     source: "Trapping Scorpies",
   },
+];
+
+const HardResourcesCards: Card[] = [
   {
     id: "Lustre_Ore",
     category: CardCategory.HardResources,
@@ -510,6 +522,9 @@ export const Cards: Card[] = [
     base: 2.5,
     source: "Catching Flycicle",
   },
+];
+
+const FrostbiteTundraCards: Card[] = [
   {
     id: "Sheepie",
     category: CardCategory.FrostbiteTundra,
@@ -622,6 +637,9 @@ export const Cards: Card[] = [
     base: 3,
     source: "",
   },
+];
+
+const BossesCards: Card[] = [
   {
     id: "Baba_Yaga",
     category: CardCategory.Bosses,
@@ -699,6 +717,9 @@ export const Cards: Card[] = [
     base: 5,
     source: "",
   },
+];
+
+const EventsCards: Card[] = [
   {
     id: "Ghost",
     category: CardCategory.Events,
@@ -769,4 +790,15 @@ export const Cards: Card[] = [
     base: 1,
     source: "Egg Capsule",
   },
+];
+
+export const Cards: Card[] = [
+  ...BlunderHillCards,
+  ...YumYumDesertCards,
+  ...EasyResourcesCards,
+  ...MediumResourcesCards,
+  ...HardResourcesCards,
+  ...FrostbiteTundraCards,
+  ...BossesCards,
+  ...EventsCards,
 ];

--- a/src/composables/Characters.ts
+++ b/src/composables/Characters.ts
@@ -1,6 +1,6 @@
 import { computed, ref } from "vue";
 import { useState } from "~/State";
-import checklistData from "~/data/checklist.json";
+import { checklistData } from "~/composables/Checklist";
 
 export enum Class {
   Beginner = "Beginner",

--- a/src/composables/Characters.ts
+++ b/src/composables/Characters.ts
@@ -82,7 +82,7 @@ export class Character {
     for (const category of ["Inventory Bags"] as const) {
       for (const item of checklistData[category].items) {
         if (this.hasItem(item.name)) {
-          slots += item.bagSlots;
+          slots += item.bagSlots ?? 0;
         }
       }
     }
@@ -90,7 +90,7 @@ export class Character {
     for (const category of ["Gem Shop Bags"] as const) {
       for (const item of checklistData[category].items) {
         if (checklist[item.name] === true) {
-          slots += item.bagSlots;
+          slots += item.bagSlots ?? 0;
         }
       }
     }

--- a/src/composables/Checklist.ts
+++ b/src/composables/Checklist.ts
@@ -94,12 +94,12 @@ const InventoryBags: StorageItem[] = [
   {
     name: "Capitalist Case",
     bagSlots: 1,
-    source: "Vendor (Encroaching Forest Villa)",
+    source: "Vendor (Encroaching Forest Villas)",
   },
   {
     name: "Wealthy Wallet",
     bagSlots: 1,
-    source: "Vendor (Yum Yum Grotto)",
+    source: "Vendor (YumYum Grotto)",
   },
   {
     name: "Prosperous Pouch",
@@ -346,54 +346,67 @@ const StorageChests: StorageItem[] = [
   {
     name: "Storage Chest 1",
     bagSlots: 3,
+    source: "Quest (Hamish)",
   },
   {
     name: "Storage Chest 2",
     bagSlots: 3,
+    source: "Vendor (Blunder Hills)",
   },
   {
     name: "Storage Chest 3",
     bagSlots: 3,
+    source: "Quest (Krunk)",
   },
   {
     name: "Storage Chest 4",
     bagSlots: 3,
+    source: "Quest (Cowbo Jones)",
   },
   {
     name: "Storage Chest 5",
     bagSlots: 3,
+    source: "Quest (Mutton)",
   },
   {
     name: "Storage Chest 6",
     bagSlots: 4,
+    source: "Vendor (Blunder Hills)",
   },
   {
     name: "Storage Chest 7",
     bagSlots: 4,
+    source: "Vendor (Blunder Hills)",
   },
   {
     name: "Storage Chest 8",
     bagSlots: 4,
+    source: "Vendor (Encroaching Forest Villas)",
   },
   {
     name: "Storage Chest 9",
     bagSlots: 4,
+    source: "Vendor (YumYum Grotto)",
   },
   {
     name: "Storage Chest 10",
     bagSlots: 5,
+    source: "Vendor (YumYum Grotto)",
   },
   {
     name: "Storage Chest 11",
     bagSlots: 5,
+    source: "Quest (Snake Jar)",
   },
   {
     name: "Storage Chest 12",
     bagSlots: 5,
+    source: "Vendor (Encroaching Forest Villas)",
   },
   {
     name: "Storage Chest 13",
     bagSlots: 5,
+    source: "Vendor (YumYum Grotto)",
   },
   {
     name: "Storage Chest 14",
@@ -402,82 +415,102 @@ const StorageChests: StorageItem[] = [
   {
     name: "Storage Chest 15",
     bagSlots: 6,
+    source: "Vendor (YumYum Grotto)",
   },
   {
     name: "Storage Chest 16",
     bagSlots: 6,
+    source: "Vendor (Frostbite Towndra)",
   },
   {
     name: "Storage Chest 17",
     bagSlots: 6,
+    source: "Vendor (Frostbite Towndra)",
   },
   {
     name: "Storage Chest 18",
     bagSlots: 6,
+    source: "Vendor (Frostbite Towndra)",
   },
   {
     name: "Storage Chest 19",
     bagSlots: 6,
+    source: "Vendor (Frostbite Towndra)",
   },
   {
     name: "Storage Chest 20",
     bagSlots: 7,
+    source: "Vendor (Frostbite Towndra)",
   },
   {
     name: "Storage Chest 21",
     bagSlots: 7,
+    source: "Vendor (Frostbite Towndra)",
   },
   {
     name: "Storage Chest 90",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 91",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 92",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 93",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 94",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 95",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 96",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 97",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 98",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 99",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 99B",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Storage Chest 99C",
     bagSlots: 6,
+    source: "Gem Shop",
   },
   {
     name: "Dank Paypay Chest",
     bagSlots: 6,
+    source: "Frog"
   },
 ]
 

--- a/src/composables/Checklist.ts
+++ b/src/composables/Checklist.ts
@@ -1,17 +1,6 @@
-type ChecklistItem = {
-  name: string;
-  source?: string;
-}
+import { Item, ItemGroup } from "./Utilities";
 
-type StorageItem = ChecklistItem & {
-  bagSlots: number;
-}
-
-type CapacityPouchesItem = ChecklistItem & {
-  cycle: string;
-}
-
-const InventoryBags: StorageItem[] = [
+const InventoryBags: Item[] = [
   {
     name: "Inventory Bag A",
     bagSlots: 1,
@@ -112,7 +101,7 @@ const InventoryBags: StorageItem[] = [
   },
 ]
 
-const GemShopBags: StorageItem[] = [
+const GemShopBags: Item[] = [
   {
     name: "Inventory Bag U",
     bagSlots: 4,
@@ -145,7 +134,7 @@ const GemShopBags: StorageItem[] = [
   },
 ]
 
-const CapacityPouches: CapacityPouchesItem[] = [
+const CapacityPouches: Item[] = [
   {
     name: "Mini Materials Pouch",
     cycle: "Materials Pouch",
@@ -348,7 +337,7 @@ const CapacityPouches: CapacityPouchesItem[] = [
   },
 ]
 
-const StorageChests: StorageItem[] = [
+const StorageChests: Item[] = [
   {
     name: "Storage Chest 1",
     bagSlots: 3,
@@ -520,7 +509,7 @@ const StorageChests: StorageItem[] = [
   },
 ]
 
-const CombatStamps: ChecklistItem[] = [
+const CombatStamps: Item[] = [
   {
     name: "Sword Stamp",
     source: "Start",
@@ -627,7 +616,7 @@ const CombatStamps: ChecklistItem[] = [
   },
 ]
 
-const SkillStamps: ChecklistItem[] = [
+const SkillStamps: Item[] = [
   {
     name: "Pickaxe Stamp",
     source: "Start",
@@ -757,7 +746,7 @@ const SkillStamps: ChecklistItem[] = [
   },
 ]
 
-const MiscStamps: ChecklistItem[] = [
+const MiscStamps: Item[] = [
   {
     name: "Questin Stamp",
     source: "Quest (Tiki Chief)",
@@ -815,7 +804,7 @@ const MiscStamps: ChecklistItem[] = [
   },
 ]
 
-export const checklistData = {
+export const checklistData: Record<string, ItemGroup> = {
   "Inventory Bags": {
     global: false,
     assetDir: "checklist",

--- a/src/composables/Checklist.ts
+++ b/src/composables/Checklist.ts
@@ -134,63 +134,83 @@ const GemShopBags: Item[] = [
   },
 ]
 
-const CapacityPouches: Item[] = [
+const MaterialPouches: Item[] = [
   {
     name: "Mini Materials Pouch",
     cycle: "Materials Pouch",
+    source: "Quest (Scripticus)",
   },
   {
     name: "Cramped Materials Pouch",
     cycle: "Materials Pouch",
+    source: "Smithing",
   },
   {
     name: "Small Materials Pouch",
     cycle: "Materials Pouch",
+    source: "Quest (Scripticus)",
   },
   {
     name: "Average Materials Pouch",
     cycle: "Materials Pouch",
+    source: "Smithing",
   },
   {
     name: "Sizable Materials Pouch",
     cycle: "Materials Pouch",
+    source: "Smithing",
   },
   {
     name: "Big Materials Pouch",
     cycle: "Materials Pouch",
+    source: "Smithing",
   },
   {
     name: "Large Materials Pouch",
     cycle: "Materials Pouch",
+    source: "Smithing",
   },
+]
+
+const MiningPouches: Item[] = [
   {
     name: "Miniature Mining Pouch",
     cycle: "Mining Pouch",
+    source: "Quest (Glumlee)",
   },
   {
     name: "Cramped Mining Pouch",
     cycle: "Mining Pouch",
+    source: "Smithing",
   },
   {
     name: "Small Mining Pouch",
     cycle: "Mining Pouch",
+    source: "Smithing",
   },
   {
     name: "Average Mining Pouch",
     cycle: "Mining Pouch",
+    source: "Smithing",
   },
   {
     name: "Sizable Mining Pouch",
     cycle: "Mining Pouch",
+    source: "Smithing",
   },
   {
     name: "Big Mining Pouch",
     cycle: "Mining Pouch",
+    source: "Smithing",
   },
   {
     name: "Large Mining Pouch",
     cycle: "Mining Pouch",
+    source: "Smithing",
   },
+];
+
+const FishingPouches: Item[] = [
   {
     name: "Miniature Fish Pouch",
     cycle: "Fishing Pouch",
@@ -198,83 +218,112 @@ const CapacityPouches: Item[] = [
   {
     name: "Cramped Fish Pouch",
     cycle: "Fishing Pouch",
+    source: "Smithing",
   },
   {
     name: "Small Fish Pouch",
     cycle: "Fishing Pouch",
+    source: "Smithing",
   },
   {
     name: "Average Fish Pouch",
     cycle: "Fishing Pouch",
+    source: "Smithing",
   },
   {
     name: "Sizable Fish Pouch",
     cycle: "Fishing Pouch",
+    source: "Smithing",
   },
   {
     name: "Big Fish Pouch",
     cycle: "Fishing Pouch",
+    source: "Smithing",
   },
   {
     name: "Large Fish Pouch",
     cycle: "Fishing Pouch",
+    source: "Smithing",
   },
+]
+
+const FoodPouches: Item[] = [
   {
     name: "Miniscule Food Pouch",
     cycle: "Food Pouch",
+    source: "Quest (Picnic Stowaway",
   },
   {
     name: "Cramped Food Pouch",
     cycle: "Food Pouch",
+    source: "Smithing",
   },
   {
     name: "Small Food Pouch",
     cycle: "Food Pouch",
+    source: "Quest (Funguy)",
   },
   {
     name: "Average Food Pouch",
     cycle: "Food Pouch",
+    source: "Smithing",
   },
   {
     name: "Sizable Food Pouch",
     cycle: "Food Pouch",
+    source: "Smithing",
   },
   {
     name: "Big Food Pouch",
     cycle: "Food Pouch",
+    source: "Smithing",
   },
   {
     name: "Large Food Pouch",
     cycle: "Food Pouch",
+    source: "Smithing",
   },
+];
+
+const ChoppinPouches: Item[] = [
   {
     name: "Miniature Choppin Pouch",
     cycle: "Choppin Pouch",
+    source: "Quest (Woodsman)",
   },
   {
     name: "Cramped Choppin Pouch",
     cycle: "Choppin Pouch",
+    source: "Smithing",
   },
   {
     name: "Small Choppin Pouch",
     cycle: "Choppin Pouch",
+    source: "Smithing",
   },
   {
     name: "Average Choppin Pouch",
     cycle: "Choppin Pouch",
+    source: "Smithing",
   },
   {
     name: "Sizable Choppin Pouch",
     cycle: "Choppin Pouch",
+    source: "Smithing",
   },
   {
     name: "Big Choppin Pouch",
     cycle: "Choppin Pouch",
+    source: "Smithing",
   },
   {
     name: "Large Choppin Pouch",
     cycle: "Choppin Pouch",
+    source: "Smithing",
   },
+];
+
+const BugPouches: Item[] = [
   {
     name: "Miniature Bug Pouch",
     cycle: "Bug Pouch",
@@ -282,58 +331,78 @@ const CapacityPouches: Item[] = [
   {
     name: "Cramped Bug Pouch",
     cycle: "Bug Pouch",
+    source: "Smithing",
   },
   {
     name: "Small Bug Pouch",
     cycle: "Bug Pouch",
+    source: "Smithing",
   },
   {
     name: "Average Bug Pouch",
     cycle: "Bug Pouch",
+    source: "Smithing",
   },
   {
     name: "Sizable Bug Pouch",
     cycle: "Bug Pouch",
+    source: "Smithing",
   },
   {
     name: "Big Bug Pouch",
     cycle: "Bug Pouch",
+    source: "Smithing",
   },
   {
     name: "Large Bug Pouch",
     cycle: "Bug Pouch",
+    source: "Smithing",
   },
+];
+
+const CritterPouches: Item[] = [
   {
     name: "Small Critter Pouch",
     cycle: "Critter Pouch",
+    source: "Smithing",
   },
   {
     name: "Sizable Critter Pouch",
     cycle: "Critter Pouch",
+    source: "Smithing",
   },
   {
     name: "Big Critter Pouch",
     cycle: "Critter Pouch",
+    source: "Smithing",
   },
   {
     name: "Large Critter Pouch",
     cycle: "Critter Pouch",
+    source: "Smithing",
   },
+];
+
+const SoulPouches: Item[] = [
   {
     name: "Small Soul Pouch",
     cycle: "Soul Pouch",
+    source: "Smithing",
   },
   {
     name: "Sizable Soul Pouch",
     cycle: "Soul Pouch",
+    source: "Smithing",
   },
   {
     name: "Big Soul Pouch",
     cycle: "Soul Pouch",
+    source: "Smithing",
   },
   {
     name: "Large Soul Pouch",
     cycle: "Soul Pouch",
+    source: "Smithing",
   },
 ]
 
@@ -818,7 +887,16 @@ export const checklistData: Record<string, ItemGroup> = {
   "Capacity Pouches": {
     global: false,
     assetDir: "checklist",
-    items: CapacityPouches,
+    items: [
+      ...MaterialPouches,
+      ...MiningPouches,
+      ...FishingPouches,
+      ...FoodPouches,
+      ...ChoppinPouches,
+      ...BugPouches,
+      ...CritterPouches,
+      ...SoulPouches,
+    ],
   },
   "Storage Chests": {
     global: true,

--- a/src/composables/Checklist.ts
+++ b/src/composables/Checklist.ts
@@ -516,88 +516,114 @@ const StorageChests: StorageItem[] = [
   {
     name: "Dank Paypay Chest",
     bagSlots: 6,
-    source: "Drop (Frog)"
+    source: "Drop (Frog)",
   },
 ]
 
 const CombatStamps: ChecklistItem[] = [
   {
     name: "Sword Stamp",
+    source: "Start",
   },
   {
     name: "Heart Stamp",
+    source: "Start",
   },
   {
     name: "Mana Stamp",
+    source: "Vendor (Blunder Hills)",
   },
   {
     name: "Tomahawk Stamp",
+    source: "Quest (Hamish)",
   },
   {
     name: "Target Stamp",
+    source: "Vendor (Blunder Hills)",
   },
   {
     name: "Shield Stamp",
+    source: "Vendor (Blunder Hills)",
   },
   {
     name: "Longsword Stamp",
+    source: "Drop (Baby Boa)",
   },
   {
     name: "Kapow Stamp",
+    source: "Drop (Gigafrog)",
   },
   {
     name: "Fist Stamp",
+    source: "Quest (Mutton)",
   },
   {
     name: "Battleaxe Stamp",
+    source: "Drop (Gigafrog)",
   },
   {
     name: "Agile Stamp",
+    source: "DropTable12",
   },
   {
     name: "Vitality Stamp",
+    source: "Vendor (Encroaching Forest Villas)"
   },
   {
     name: "Book Stamp",
+    source: "DropTable10",
   },
   {
     name: "Manamoar Stamp",
+    source: "Quest (Mutton)",
   },
   {
     name: "Clover Stamp",
+    source: "Vendor (Faraway Piers)",
   },
   {
     name: "Scimitar Stamp",
+    source: "Quest (Mutton)",
   },
   {
     name: "Bullseye Stamp",
+    source: "Quest (Mutton)",
   },
   {
     name: "Feather Stamp",
+    source: "Quest (Snouts)",
   },
   {
     name: "Polearm Stamp",
+    source: "Quest (Papua Piggea)",
   },
   {
     name: "Violence Stamp",
+    source: "DropTable15",
   },
   {
     name: "Buckler Stamp",
+    source: "Quest (Snouts)",
   },
   {
     name: "Sukka Foo Stamp",
+    source: "Alchemy (Level Up Gift)",
   },
   {
     name: "Arcane Stamp",
+    source: "Quest (Wellington)",
   },
   {
     name: "Steve Sword Stamp",
+    source: "Quest (Mutton)",
   },
   {
     name: "Blover Stamp",
+    source: "DropTable16",
   },
   {
     name: "Stat Graph Stamp",
+    source: "Quest (XxX Cattleprod XxX)",
   },
 ]
 

--- a/src/composables/Checklist.ts
+++ b/src/composables/Checklist.ts
@@ -59,17 +59,17 @@ const InventoryBags: StorageItem[] = [
   {
     name: "Snakeskinventory Bag",
     bagSlots: 2,
-    source: "Baby Boa",
+    source: "Drop (Baby Boa)",
   },
   {
     name: "Totally Normal And Not Fake Bag",
     bagSlots: 2,
-    source: "Mimic",
+    source: "Drop (Mimic)",
   },
   {
     name: "Mamooth Hide Bag",
     bagSlots: 1,
-    source: "Mamooth",
+    source: "Drop (Mamooth)",
   },
   {
     name: "Blunderbag",
@@ -116,26 +116,32 @@ const GemShopBags: StorageItem[] = [
   {
     name: "Inventory Bag U",
     bagSlots: 4,
+    source: "Gem Shop",
   },
   {
     name: "Inventory Bag V",
     bagSlots: 4,
+    source: "Gem Shop",
   },
   {
     name: "Inventory Bag W",
     bagSlots: 4,
+    source: "Gem Shop",
   },
   {
     name: "Inventory Bag X",
     bagSlots: 4,
+    source: "Gem Shop",
   },
   {
     name: "Inventory Bag Y",
     bagSlots: 4,
+    source: "Gem Shop",
   },
   {
     name: "Inventory Bag Z",
     bagSlots: 4,
+    source: "Gem Shop",
   },
 ]
 
@@ -510,7 +516,7 @@ const StorageChests: StorageItem[] = [
   {
     name: "Dank Paypay Chest",
     bagSlots: 6,
-    source: "Frog"
+    source: "Drop (Frog)"
   },
 ]
 

--- a/src/composables/Checklist.ts
+++ b/src/composables/Checklist.ts
@@ -760,33 +760,41 @@ const SkillStamps: ChecklistItem[] = [
 const MiscStamps: ChecklistItem[] = [
   {
     name: "Questin Stamp",
+    source: "Quest (Tiki Chief)",
   },
   {
     name: "Mason Jar Stamp",
+    source: "Quest (XxX Cattleprod XxX)",
   },
   {
     name: "Crystallin Stamp",
+    source: "Drop (Crystal Monsters)",
   },
   {
     name: "Apple Stamp",
   },
   {
     name: "Potion Stamp",
+    source: "Quest (Papua Piggea)",
   },
   {
     name: "Golden Apple Stamp",
+    source: "Quest (Mutton)",
   },
   {
     name: "Card Stamp",
+    source: "Alchemy (Level Up Gift)",
   },
   {
     name: "Talent I Stamp",
   },
   {
     name: "Talent II Stamp",
+    source: "Quest (Wellington)",
   },
   {
     name: "Talent III Stamp",
+    source: "Quest (Snouts)",
   },
   {
     name: "Talent IV Stamp",
@@ -799,9 +807,11 @@ const MiscStamps: ChecklistItem[] = [
   },
   {
     name: "Multikill Stamp",
+    source: "DropTable15",
   },
   {
     name: "Biblio Stamp",
+    source: "Quest (Snouts)",
   },
 ]
 

--- a/src/composables/Checklist.ts
+++ b/src/composables/Checklist.ts
@@ -1,0 +1,730 @@
+type ChecklistItem = {
+  name: string
+  source?: string
+}
+
+type StorageItem = ChecklistItem & {
+  bagSlots: number
+}
+
+type CapacityPouchesItem = ChecklistItem & {
+  cycle: string
+}
+
+const InventoryBags: StorageItem[] = [
+  {
+    name: "Inventory Bag A",
+    bagSlots: 1,
+  },
+  {
+    name: "Inventory Bag B",
+    bagSlots: 1,
+  },
+  {
+    name: "Inventory Bag C",
+    bagSlots: 1,
+  },
+  {
+    name: "Inventory Bag D",
+    bagSlots: 2,
+  },
+  {
+    name: "Inventory Bag E",
+    bagSlots: 2,
+  },
+  {
+    name: "Inventory Bag F",
+    bagSlots: 2,
+  },
+  {
+    name: "Inventory Bag G",
+    bagSlots: 2,
+  },
+  {
+    name: "Inventory Bag H",
+    bagSlots: 2,
+  },
+  {
+    name: "Inventory Bag I",
+    bagSlots: 2,
+  },
+  {
+    name: "Snakeskinventory Bag",
+    bagSlots: 2,
+  },
+  {
+    name: "Totally Normal And Not Fake Bag",
+    bagSlots: 2,
+  },
+  {
+    name: "Mamooth Hide Bag",
+    bagSlots: 1,
+  },
+  {
+    name: "Blunderbag",
+    bagSlots: 4,
+  },
+  {
+    name: "Sandy Satchel",
+    bagSlots: 4,
+  },
+  {
+    name: "Shivering Sack",
+    bagSlots: 3,
+  },
+  {
+    name: "Bummo Bag",
+    bagSlots: 1,
+  },
+  {
+    name: "Capitalist Case",
+    bagSlots: 1,
+  },
+  {
+    name: "Wealthy Wallet",
+    bagSlots: 1,
+  },
+  {
+    name: "Prosperous Pouch",
+    bagSlots: 1,
+  },
+  {
+    name: "Sack of Success",
+    bagSlots: 2,
+  },
+]
+
+const GemShopBags: StorageItem[] = [
+  {
+    name: "Inventory Bag U",
+    bagSlots: 4,
+  },
+  {
+    name: "Inventory Bag V",
+    bagSlots: 4,
+  },
+  {
+    name: "Inventory Bag W",
+    bagSlots: 4,
+  },
+  {
+    name: "Inventory Bag X",
+    bagSlots: 4,
+  },
+  {
+    name: "Inventory Bag Y",
+    bagSlots: 4,
+  },
+  {
+    name: "Inventory Bag Z",
+    bagSlots: 4,
+  },
+]
+
+const CapacityPouches: CapacityPouchesItem[] = [
+  {
+    name: "Mini Materials Pouch",
+    cycle: "Materials Pouch",
+  },
+  {
+    name: "Cramped Materials Pouch",
+    cycle: "Materials Pouch",
+  },
+  {
+    name: "Small Materials Pouch",
+    cycle: "Materials Pouch",
+  },
+  {
+    name: "Average Materials Pouch",
+    cycle: "Materials Pouch",
+  },
+  {
+    name: "Sizable Materials Pouch",
+    cycle: "Materials Pouch",
+  },
+  {
+    name: "Big Materials Pouch",
+    cycle: "Materials Pouch",
+  },
+  {
+    name: "Large Materials Pouch",
+    cycle: "Materials Pouch",
+  },
+  {
+    name: "Miniature Mining Pouch",
+    cycle: "Mining Pouch",
+  },
+  {
+    name: "Cramped Mining Pouch",
+    cycle: "Mining Pouch",
+  },
+  {
+    name: "Small Mining Pouch",
+    cycle: "Mining Pouch",
+  },
+  {
+    name: "Average Mining Pouch",
+    cycle: "Mining Pouch",
+  },
+  {
+    name: "Sizable Mining Pouch",
+    cycle: "Mining Pouch",
+  },
+  {
+    name: "Big Mining Pouch",
+    cycle: "Mining Pouch",
+  },
+  {
+    name: "Large Mining Pouch",
+    cycle: "Mining Pouch",
+  },
+  {
+    name: "Miniature Fish Pouch",
+    cycle: "Fishing Pouch",
+  },
+  {
+    name: "Cramped Fish Pouch",
+    cycle: "Fishing Pouch",
+  },
+  {
+    name: "Small Fish Pouch",
+    cycle: "Fishing Pouch",
+  },
+  {
+    name: "Average Fish Pouch",
+    cycle: "Fishing Pouch",
+  },
+  {
+    name: "Sizable Fish Pouch",
+    cycle: "Fishing Pouch",
+  },
+  {
+    name: "Big Fish Pouch",
+    cycle: "Fishing Pouch",
+  },
+  {
+    name: "Large Fish Pouch",
+    cycle: "Fishing Pouch",
+  },
+  {
+    name: "Miniscule Food Pouch",
+    cycle: "Food Pouch",
+  },
+  {
+    name: "Cramped Food Pouch",
+    cycle: "Food Pouch",
+  },
+  {
+    name: "Small Food Pouch",
+    cycle: "Food Pouch",
+  },
+  {
+    name: "Average Food Pouch",
+    cycle: "Food Pouch",
+  },
+  {
+    name: "Sizable Food Pouch",
+    cycle: "Food Pouch",
+  },
+  {
+    name: "Big Food Pouch",
+    cycle: "Food Pouch",
+  },
+  {
+    name: "Large Food Pouch",
+    cycle: "Food Pouch",
+  },
+  {
+    name: "Miniature Choppin Pouch",
+    cycle: "Choppin Pouch",
+  },
+  {
+    name: "Cramped Choppin Pouch",
+    cycle: "Choppin Pouch",
+  },
+  {
+    name: "Small Choppin Pouch",
+    cycle: "Choppin Pouch",
+  },
+  {
+    name: "Average Choppin Pouch",
+    cycle: "Choppin Pouch",
+  },
+  {
+    name: "Sizable Choppin Pouch",
+    cycle: "Choppin Pouch",
+  },
+  {
+    name: "Big Choppin Pouch",
+    cycle: "Choppin Pouch",
+  },
+  {
+    name: "Large Choppin Pouch",
+    cycle: "Choppin Pouch",
+  },
+  {
+    name: "Miniature Bug Pouch",
+    cycle: "Bug Pouch",
+  },
+  {
+    name: "Cramped Bug Pouch",
+    cycle: "Bug Pouch",
+  },
+  {
+    name: "Small Bug Pouch",
+    cycle: "Bug Pouch",
+  },
+  {
+    name: "Average Bug Pouch",
+    cycle: "Bug Pouch",
+  },
+  {
+    name: "Sizable Bug Pouch",
+    cycle: "Bug Pouch",
+  },
+  {
+    name: "Big Bug Pouch",
+    cycle: "Bug Pouch",
+  },
+  {
+    name: "Large Bug Pouch",
+    cycle: "Bug Pouch",
+  },
+  {
+    name: "Small Critter Pouch",
+    cycle: "Critter Pouch",
+  },
+  {
+    name: "Sizable Critter Pouch",
+    cycle: "Critter Pouch",
+  },
+  {
+    name: "Big Critter Pouch",
+    cycle: "Critter Pouch",
+  },
+  {
+    name: "Large Critter Pouch",
+    cycle: "Critter Pouch",
+  },
+  {
+    name: "Small Soul Pouch",
+    cycle: "Soul Pouch",
+  },
+  {
+    name: "Sizable Soul Pouch",
+    cycle: "Soul Pouch",
+  },
+  {
+    name: "Big Soul Pouch",
+    cycle: "Soul Pouch",
+  },
+  {
+    name: "Large Soul Pouch",
+    cycle: "Soul Pouch",
+  }
+]
+
+const StorageChests: StorageItem[] = [
+  {
+    name: "Storage Chest 1",
+    bagSlots: 3,
+  },
+  {
+    name: "Storage Chest 2",
+    bagSlots: 3,
+  },
+  {
+    name: "Storage Chest 3",
+    bagSlots: 3,
+  },
+  {
+    name: "Storage Chest 4",
+    bagSlots: 3,
+  },
+  {
+    name: "Storage Chest 5",
+    bagSlots: 3,
+  },
+  {
+    name: "Storage Chest 6",
+    bagSlots: 4,
+  },
+  {
+    name: "Storage Chest 7",
+    bagSlots: 4,
+  },
+  {
+    name: "Storage Chest 8",
+    bagSlots: 4,
+  },
+  {
+    name: "Storage Chest 9",
+    bagSlots: 4,
+  },
+  {
+    name: "Storage Chest 10",
+    bagSlots: 5,
+  },
+  {
+    name: "Storage Chest 11",
+    bagSlots: 5,
+  },
+  {
+    name: "Storage Chest 12",
+    bagSlots: 5,
+  },
+  {
+    name: "Storage Chest 13",
+    bagSlots: 5,
+  },
+  {
+    name: "Storage Chest 14",
+    bagSlots: 5,
+  },
+  {
+    name: "Storage Chest 15",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 16",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 17",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 18",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 19",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 20",
+    bagSlots: 7,
+  },
+  {
+    name: "Storage Chest 21",
+    bagSlots: 7,
+  },
+  {
+    name: "Storage Chest 90",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 91",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 92",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 93",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 94",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 95",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 96",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 97",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 98",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 99",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 99B",
+    bagSlots: 6,
+  },
+  {
+    name: "Storage Chest 99C",
+    bagSlots: 6,
+  },
+  {
+    name: "Dank Paypay Chest",
+    bagSlots: 6,
+  },
+];
+
+const CombatStamps: ChecklistItem[] = [
+  {
+    name: "Sword Stamp",
+  },
+  {
+    name: "Heart Stamp",
+  },
+  {
+    name: "Mana Stamp",
+  },
+  {
+    name: "Tomahawk Stamp",
+  },
+  {
+    name: "Target Stamp",
+  },
+  {
+    name: "Shield Stamp",
+  },
+  {
+    name: "Longsword Stamp",
+  },
+  {
+    name: "Kapow Stamp",
+  },
+  {
+    name: "Fist Stamp",
+  },
+  {
+    name: "Battleaxe Stamp",
+  },
+  {
+    name: "Agile Stamp",
+  },
+  {
+    name: "Vitality Stamp",
+  },
+  {
+    name: "Book Stamp",
+  },
+  {
+    name: "Manamoar Stamp",
+  },
+  {
+    name: "Clover Stamp",
+  },
+  {
+    name: "Scimitar Stamp",
+  },
+  {
+    name: "Bullseye Stamp",
+  },
+  {
+    name: "Feather Stamp",
+  },
+  {
+    name: "Polearm Stamp",
+  },
+  {
+    name: "Violence Stamp",
+  },
+  {
+    name: "Buckler Stamp",
+  },
+  {
+    name: "Sukka Foo Stamp",
+  },
+  {
+    name: "Arcane Stamp",
+  },
+  {
+    name: "Steve Sword Stamp",
+  },
+  {
+    name: "Blover Stamp",
+  },
+  {
+    name: "Stat Graph Stamp",
+  },
+];
+
+const SkillStamps: ChecklistItem[] = [
+  {
+    name: "Pickaxe Stamp",
+  },
+  {
+    name: "Hatchet Stamp",
+  },
+  {
+    name: "Anvil Zoomer Stamp",
+  },
+  {
+    name: "Lil' Mining Baggy Stamp",
+  },
+  {
+    name: "Twin Ores Stamp",
+  },
+  {
+    name: "Choppin' Bag Stamp",
+  },
+  {
+    name: "Duplogs Stamp",
+  },
+  {
+    name: "Matty Bag Stamp",
+  },
+  {
+    name: "Smart Dirt Stamp",
+  },
+  {
+    name: "Cool Diggy Tool Stamp",
+  },
+  {
+    name: "High IQ Lumber Stamp",
+  },
+  {
+    name: "Swag Swingy Tool Stamp",
+  },
+  {
+    name: "Smartas Smithing Stamp",
+  },
+  {
+    name: "Alch Go Brrr Stamp",
+  },
+  {
+    name: "Brainstew Stamp",
+  },
+  {
+    name: "Drippy Drop Stamp",
+  },
+  {
+    name: "Droplots Stamp",
+  },
+  {
+    name: "Fishing Rod Stamp",
+  },
+  {
+    name: "Fishhead Stamp",
+  },
+  {
+    name: "Catch Net Stamp",
+  },
+  {
+    name: "Fly Intel Stamp",
+  },
+  {
+    name: "Bag o Heads Stamp",
+  },
+  {
+    name: "Holy Mackerel Stamp",
+  },
+  {
+    name: "Bugsack Stamp",
+  },
+  {
+    name: "Buzz Buzz Stamp",
+  },
+  {
+    name: "Hidey Box Stamp",
+  },
+  {
+    name: "Purp Froge Stamp",
+  },
+  {
+    name: "Spikemouth Stamp",
+  },
+  {
+    name: "Sample Stamp",
+  },
+  {
+    name: "Saw Stamp",
+  },
+  {
+    name: "Flowin Stamp",
+  },
+  {
+    name: "Banked Pts Stamp",
+  },
+];
+
+const MiscStamps: ChecklistItem[] = [
+  {
+    name: "Questin Stamp",
+  },
+  {
+    name: "Mason Jar Stamp",
+  },
+  {
+    name: "Crystallin Stamp",
+  },
+  {
+    name: "Apple Stamp",
+  },
+  {
+    name: "Potion Stamp",
+  },
+  {
+    name: "Golden Apple Stamp",
+  },
+  {
+    name: "Card Stamp",
+  },
+  {
+    name: "Talent I Stamp",
+  },
+  {
+    name: "Talent II Stamp",
+  },
+  {
+    name: "Talent III Stamp",
+  },
+  {
+    name: "Talent IV Stamp",
+  },
+  {
+    name: "Talent V Stamp",
+  },
+  {
+    name: "Talent S Stamp",
+  },
+  {
+    name: "Multikill Stamp",
+  },
+  {
+    name: "Biblio Stamp",
+  },
+];
+
+export const checklistData = {
+  "Inventory Bags": {
+    global: false,
+    assetDir: "checklist",
+    items: InventoryBags,
+  },
+  "Gem Shop Bags": {
+    global: true,
+    assetDir: "checklist",
+    items: GemShopBags,
+  },
+  "Capacity Pouches": {
+    global: false,
+    assetDir: "checklist",
+    items: CapacityPouches,
+  },
+  "Storage Chests": {
+    global: true,
+    assetDir: "checklist",
+    items: StorageChests,
+  },
+  "Combat Stamps": {
+    global: true,
+    assetDir: "stamps",
+    items: CombatStamps,
+  },
+  "Skill Stamps": {
+    global: true,
+    assetDir: "stamps",
+    items: SkillStamps,
+  },
+  "Misc Stamps": {
+    global: true,
+    assetDir: "stamps",
+    items: MiscStamps,
+  },
+}

--- a/src/composables/Checklist.ts
+++ b/src/composables/Checklist.ts
@@ -630,99 +630,130 @@ const CombatStamps: ChecklistItem[] = [
 const SkillStamps: ChecklistItem[] = [
   {
     name: "Pickaxe Stamp",
+    source: "Start",
   },
   {
     name: "Hatchet Stamp",
+    source: "Start",
   },
   {
     name: "Anvil Zoomer Stamp",
+    source: "DropTable1",
   },
   {
     name: "Lil' Mining Baggy Stamp",
+    source: "Quest (XxX Cattleprod XxX)",
   },
   {
     name: "Twin Ores Stamp",
+    source: "Drop (Sheepie)"
   },
   {
     name: "Choppin' Bag Stamp",
+    source: "Quest (Hamish)",
   },
   {
     name: "Duplogs Stamp",
+    source: "Drop (Frost Flake)",
   },
   {
     name: "Matty Bag Stamp",
+    source: "Vendor (Faraway Piers)",
   },
   {
     name: "Smart Dirt Stamp",
+    source: "DropTable5"
   },
   {
     name: "Cool Diggy Tool Stamp",
+    source: "Drop (Snowman)",
   },
   {
     name: "High IQ Lumber Stamp",
+    source: "DropTable4",
   },
   {
     name: "Swag Swingy Tool Stamp",
+    source: "Drop (Thermister)",
   },
   {
     name: "Smartas Smithing Stamp",
   },
   {
     name: "Alch Go Brrr Stamp",
+    source: "DropTable11",
   },
   {
     name: "Brainstew Stamp",
+    source: "Quest (Wellington)",
   },
   {
     name: "Drippy Drop Stamp",
+    source: "DropTable6",
   },
   {
     name: "Droplots Stamp",
+    source: "DropTable7",
   },
   {
     name: "Fishing Rod Stamp",
+    source: "Quest (Fishpaste97)",
   },
   {
     name: "Fishhead Stamp",
+    source: "Quest (XxX Cattleprod XxX)",
   },
   {
     name: "Catch Net Stamp",
+    source: "Quest (XxX Cattleprod XxX)",
   },
   {
     name: "Fly Intel Stamp",
+    source: "Quest (Wellington)",
   },
   {
     name: "Bag o Heads Stamp",
+    source: "DropTable12",
   },
   {
     name: "Holy Mackerel Stamp",
+    source: "Quest (Wellington)",
   },
   {
     name: "Bugsack Stamp",
+    source: "DropTable9",
   },
   {
     name: "Buzz Buzz Stamp",
+    source: "DropTable8",
   },
   {
     name: "Hidey Box Stamp",
+    source: "DropTable17",
   },
   {
     name: "Purp Froge Stamp",
+    source: "Quest (Snouts)",
   },
   {
     name: "Spikemouth Stamp",
+    source: "DropTable18",
   },
   {
     name: "Sample Stamp",
+    source: "DropTable14",
   },
   {
     name: "Saw Stamp",
+    source: "SuperDropTable3",
   },
   {
     name: "Flowin Stamp",
+    source: "DropTable16",
   },
   {
     name: "Banked Pts Stamp",
+    source: "DropTable14",
   },
 ]
 

--- a/src/composables/Checklist.ts
+++ b/src/composables/Checklist.ts
@@ -1,48 +1,56 @@
 type ChecklistItem = {
-  name: string
-  source?: string
+  name: string;
+  source?: string;
 }
 
 type StorageItem = ChecklistItem & {
-  bagSlots: number
+  bagSlots: number;
 }
 
 type CapacityPouchesItem = ChecklistItem & {
-  cycle: string
+  cycle: string;
 }
 
 const InventoryBags: StorageItem[] = [
   {
     name: "Inventory Bag A",
     bagSlots: 1,
+    source: "Quest (Scripticus)",
   },
   {
     name: "Inventory Bag B",
     bagSlots: 1,
+    source: "Quest (Scripticus)",
   },
   {
     name: "Inventory Bag C",
     bagSlots: 1,
+    source: "Quest (Scripticus)",
   },
   {
     name: "Inventory Bag D",
     bagSlots: 2,
+    source: "Quest (Promotheus)",
   },
   {
     name: "Inventory Bag E",
     bagSlots: 2,
+    source: "Quest (Cowbo Jones)",
   },
   {
     name: "Inventory Bag F",
     bagSlots: 2,
+    source: "Quest (Cowbo Jones)",
   },
   {
     name: "Inventory Bag G",
     bagSlots: 2,
+    source: "DropTable6",
   },
   {
     name: "Inventory Bag H",
     bagSlots: 2,
+    source: "Quest (Cowbo Jones)",
   },
   {
     name: "Inventory Bag I",
@@ -51,42 +59,52 @@ const InventoryBags: StorageItem[] = [
   {
     name: "Snakeskinventory Bag",
     bagSlots: 2,
+    source: "Baby Boa",
   },
   {
     name: "Totally Normal And Not Fake Bag",
     bagSlots: 2,
+    source: "Mimic",
   },
   {
     name: "Mamooth Hide Bag",
     bagSlots: 1,
+    source: "Mamooth",
   },
   {
     name: "Blunderbag",
     bagSlots: 4,
+    source: "Smithing",
   },
   {
     name: "Sandy Satchel",
     bagSlots: 4,
+    source: "Smithing",
   },
   {
     name: "Shivering Sack",
     bagSlots: 3,
+    source: "Smithing",
   },
   {
     name: "Bummo Bag",
     bagSlots: 1,
+    source: "Vendor (Blunder Hills)",
   },
   {
     name: "Capitalist Case",
     bagSlots: 1,
+    source: "Vendor (Encroaching Forest Villa)",
   },
   {
     name: "Wealthy Wallet",
     bagSlots: 1,
+    source: "Vendor (Yum Yum Grotto)",
   },
   {
     name: "Prosperous Pouch",
     bagSlots: 1,
+    source: "Vendor (Frostbite Towndra)",
   },
   {
     name: "Sack of Success",
@@ -321,7 +339,7 @@ const CapacityPouches: CapacityPouchesItem[] = [
   {
     name: "Large Soul Pouch",
     cycle: "Soul Pouch",
-  }
+  },
 ]
 
 const StorageChests: StorageItem[] = [
@@ -461,7 +479,7 @@ const StorageChests: StorageItem[] = [
     name: "Dank Paypay Chest",
     bagSlots: 6,
   },
-];
+]
 
 const CombatStamps: ChecklistItem[] = [
   {
@@ -542,7 +560,7 @@ const CombatStamps: ChecklistItem[] = [
   {
     name: "Stat Graph Stamp",
   },
-];
+]
 
 const SkillStamps: ChecklistItem[] = [
   {
@@ -641,7 +659,7 @@ const SkillStamps: ChecklistItem[] = [
   {
     name: "Banked Pts Stamp",
   },
-];
+]
 
 const MiscStamps: ChecklistItem[] = [
   {
@@ -689,7 +707,7 @@ const MiscStamps: ChecklistItem[] = [
   {
     name: "Biblio Stamp",
   },
-];
+]
 
 export const checklistData = {
   "Inventory Bags": {

--- a/src/composables/Utilities.ts
+++ b/src/composables/Utilities.ts
@@ -102,6 +102,9 @@ export class Text {
     if (item.bagSlots !== undefined) {
       text += `<br>+${item.bagSlots} Inventory Slots`;
     }
+    if (item.source !== undefined) {
+      text += `<br><em>Source: ${item.source}</em>`;
+    }
     return text;
   }
 }

--- a/src/composables/Utilities.ts
+++ b/src/composables/Utilities.ts
@@ -87,6 +87,7 @@ export type Item = {
   name: string;
   bagSlots?: number;
   cycle?: string;
+  source?: string;
 };
 
 export type ItemGroup = {

--- a/src/pages/Characters.vue
+++ b/src/pages/Characters.vue
@@ -183,7 +183,11 @@
                   :enabled="isEnabled(item.name)"
                   @click="handleProgressCheck(item.name, +1)"
                   @contextmenu.prevent="handleProgressCheck(item.name, -1)"
-                />
+                >
+                  <template #tooltip>
+                    <div class="text-center" v-html="Text.Item(item)"></div>
+                  </template>
+                </GameAsset>
               </div>
             </div>
           </div>

--- a/src/pages/Characters.vue
+++ b/src/pages/Characters.vue
@@ -212,7 +212,7 @@ import {
 } from "~/composables/Characters";
 import { Statues } from "~/composables/Statues";
 import { Assets, Text } from "~/composables/Utilities";
-import checklistData from "~/data/checklist.json";
+import { checklistData } from "~/composables/Checklist";
 import StatuesSection from "~/pages/Statues.vue";
 import { useAuth } from "~/State";
 

--- a/src/pages/Characters.vue
+++ b/src/pages/Characters.vue
@@ -211,7 +211,7 @@ import {
   useCharacters,
 } from "~/composables/Characters";
 import { Statues } from "~/composables/Statues";
-import { Assets, Text } from "~/composables/Utilities";
+import { Assets, Text, ItemGroup } from "~/composables/Utilities";
 import { checklistData } from "~/composables/Checklist";
 import StatuesSection from "~/pages/Statues.vue";
 import { useAuth } from "~/State";
@@ -261,7 +261,7 @@ export default defineComponent({
       .reduce((obj, [key, value]) => {
         obj[key] = value;
         return obj;
-      }, {} as Record<string, any>);
+      }, {} as Record<string, ItemGroup>);
 
     type CycleData = Record<string, string[]>;
     var cycles: CycleData = {};

--- a/src/pages/ProgressTracker.vue
+++ b/src/pages/ProgressTracker.vue
@@ -70,7 +70,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, ref } from "vue";
-import checklistData from "~/data/checklist.json";
+import { checklistData } from "~/composables/Checklist";
 
 import GameAsset from "~/components/GameAsset.vue";
 import { Card, CardCategory, Cards } from "~/composables/Cards";

--- a/src/pages/ProgressTracker.vue
+++ b/src/pages/ProgressTracker.vue
@@ -4,6 +4,8 @@
       <p class="h6 text-light bg-primary p-3 mt-3 mb-1 rounded">
         Track your account progress! Here you can check all of the global
         collectibles in game. Click on a cards to cycle through rarity levels.
+        <br>
+        For details on drops, please refer to the <a target="_blank" href="https://idleon.info/wiki/Category:Droptables">wiki page about drop tables</a>
       </p>
     </div>
   </div>
@@ -166,6 +168,13 @@ export default defineComponent({
 </script>
 
 <style lang="sass" scoped>
+@import '../styles/base.sass'
+a
+  color: lighten($info, 10%)
+  font-weight: bold
+  transition: 0.3s
+  &:hover
+    color: darken($info, 10%)
 .card-wrapper
   position: relative
   width: 62px


### PR DESCRIPTION
Fixes Musimaniac/IdleonCompanion#68

I copied the checklist data from checklist.json to composable, mostly for my own convenience while editing.

Added source description in the following formats:
- Quest (quest NPC)
- Smithing
- Drop (monster name)
- DropTableX
- Vendor (location of vendor)

Also added missing slot information for storage chests.

Smithing recipes are usually either unlocked from the start or gained via tasks, so I didn't add additional information.

DropTableX was kinda hard to give a short and precise summary as e.g. DropTable1 includes Green Mushroom, Frog, Bored Bean, Colosseum, Red Mushroom, Crystal Carrot, Amaraok and Baba Yaga. Therefore I left it as DropTableX.

Example:
<img width="187" alt="IDC-SourceSmithing" src="https://user-images.githubusercontent.com/42550923/124389709-a8f3b780-dce8-11eb-9329-a1127522572a.png">
